### PR TITLE
Fix typo in call for lightning talks

### DIFF
--- a/cfl.html
+++ b/cfl.html
@@ -116,7 +116,7 @@ You can submit a proposal for lightning talk by sending an email to <img src="im
       <li><b><i>Speaker’s name:</i></b></li>
       <li><b><i>Affiliation:</i></b></li>
       <li><b><i>Email:</i></b></li>
-      <li><b><i>Abstract of the talk (300-500 pages) included in a PDF formatted using <a href="templates/vldb-workshop-style-master.zip"><b>VLDB workshop style latex template</b></a></i></b>. The PDF should be at most 1 page including references.</li>
+      <li><b><i>Abstract of the talk (300-500 words) included in a PDF formatted using <a href="templates/vldb-workshop-style-master.zip"><b>VLDB workshop style latex template</b></a></i></b>. The PDF should be at most 1 page including references.</li>
       <li><a href="templates/VLDB_Copyright_License_Form.pdf"><b>A copyright form</b></a> that will have to be completed for all papers.</li>
       </ul>
 </p>


### PR DESCRIPTION
I saw this typo on the Call for Lightning Talks page. I assume this should have been `words` instead of `pages`.